### PR TITLE
feat:(individual participant):add participant entity and service

### DIFF
--- a/src/team/entities/indivudal-participant.entity.ts
+++ b/src/team/entities/indivudal-participant.entity.ts
@@ -1,0 +1,62 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Hackathon } from 'src/hackathon/entities/hackathon.entity';
+import { User } from 'src/user/entities/user.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+/*
+ * Represents an individual participant in a hackathon.
+ * They are registered as independent users and can later be invited to teams.
+ */
+@Entity('individual_participants')
+export class IndividualParticipant {
+  @ApiProperty({
+    description: 'Unique identifier of the individual participant',
+    example: 1,
+  })
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @ApiProperty({
+    description: 'The user who is participating in the hackathon',
+    type: () => User,
+  })
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @ApiProperty({
+    description: 'The ID of the user participating',
+    example: 42,
+  })
+  @Column()
+  userId: number;
+
+  @ApiProperty({
+    description: 'The hackathon in which the participant is registered',
+    type: () => Hackathon,
+  })
+  @ManyToOne(() => Hackathon)
+  @JoinColumn({ name: 'hackathonId' })
+  hackathon: Hackathon;
+
+  @ApiProperty({
+    description: 'The ID of the hackathon',
+    example: 7,
+  })
+  @Column()
+  hackathonId: number;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updatedAt: Date;
+}

--- a/src/team/entities/team.entity.ts
+++ b/src/team/entities/team.entity.ts
@@ -6,7 +6,6 @@ import {
   Column,
   CreateDateColumn,
   Entity,
-  Generated,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,

--- a/src/team/services/individual_participant.service.ts
+++ b/src/team/services/individual_participant.service.ts
@@ -1,0 +1,71 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IndividualParticipant } from '../entities/indivudal-participant.entity';
+import { Between, FindOptionsSelect, Repository } from 'typeorm';
+import {
+  PaginationDtoRes,
+  PaginationQueryDto,
+} from 'src/common/dtos/pagination.dto';
+import { User } from 'src/user/entities/user.entity';
+
+@Injectable()
+export class IndividualParticipantService {
+  constructor(
+    @InjectRepository(IndividualParticipant)
+    private readonly individualParticipantRepo: Repository<IndividualParticipant>,
+  ) {}
+  async createParticipant(userId: number, hackathonId: number) {
+    const participant = this.individualParticipantRepo.create({
+      hackathonId,
+      userId,
+    });
+    await this.individualParticipantRepo.save(participant);
+  }
+  //TODO: need to implement seach and filters here
+  async findAllParticipants(
+    hackathonId: number,
+    { take = 10, lastId = 0 }: PaginationQueryDto,
+  ) {
+    const participants = await this.individualParticipantRepo.find({
+      where: {
+        id: Between(lastId, lastId + take),
+        hackathonId,
+      },
+      //priotity to the old one
+      order: { createdAt: 'ASC' },
+      relations: ['user'],
+      select: {
+        user: { ...IndividualParticipantService.getDisplayUserSelect() },
+      },
+    });
+    const hasMore = participants.length === take;
+    const newLastId =
+      participants.length > 0
+        ? participants[participants.length - 1].id
+        : lastId;
+    return new PaginationDtoRes(participants, take, newLastId, hasMore);
+  }
+  async removeParticipant(participantId: number) {
+    const { affected } =
+      await this.individualParticipantRepo.delete(participantId);
+    if (!affected)
+      throw new NotFoundException(
+        `the participant with id ${participantId} is not found`,
+      );
+    return {
+      success: true,
+      message: `participant with id ${participantId} is removed successfully`,
+    };
+  }
+
+  static getDisplayUserSelect(): FindOptionsSelect<User> {
+    return {
+      id: true,
+      username: true,
+      info: {
+        firstName: true,
+        lastName: true,
+      },
+    };
+  }
+}

--- a/src/team/services/team.service.ts
+++ b/src/team/services/team.service.ts
@@ -9,7 +9,7 @@ import { randomBytes } from 'crypto';
 import { CreateTeamDto } from '../dto/create-team.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Team } from '../entities/team.entity';
-import { MoreThan, Repository } from 'typeorm';
+import { Between, Repository } from 'typeorm';
 import { RedisService } from 'src/redis/redis.service';
 import {
   PaginationDtoRes,
@@ -96,12 +96,11 @@ export class TeamService {
     { take = 10, lastId = 0 }: PaginationQueryDto,
     hackathonId: number,
   ) {
-    const [teams] = await this.teamRepo.findAndCount({
+    const teams = await this.teamRepo.find({
       where: {
-        id: MoreThan(lastId),
+        id: Between(lastId, lastId + take),
         hackathonId,
       },
-      take: take + 1,
       order: { id: 'ASC' },
     });
     const hasMore = teams.length === take;

--- a/src/team/services/team_invite.service.ts
+++ b/src/team/services/team_invite.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class TeamInviteService {
+  async create(participantId: number, teamId: number, dto: any) {}
+  async update(participantId: number, teamId: number, dto: any) {}
+  async remove(invitationId: number) {}
+}


### PR DESCRIPTION
This PR introduces the Individual Participant feature.

#### **Scope**

- Added IndividualParticipant entity to store hackathon participants outside of teams.

- Implemented ParticipantService with basic operations:

- Register participant (create entry in table)

- Cancel participation (remove entry)

- Fetch multiple participants

#### **Next Steps (future PRs)**

- Implement Invitation Service (team → participant invitations).

- Add Controller layer for participant endpoints.

- Seed initial Team data for development/testi

- add unit tests